### PR TITLE
Support all BG compression types

### DIFF
--- a/formats/__init__.py
+++ b/formats/__init__.py
@@ -1,1 +1,1 @@
-from formats import gds, bg, pcm, puzzle, ndsrom
+from formats import gds, bg, pcm, puzzle, ndsrom, compression

--- a/formats/compression/__init__.py
+++ b/formats/compression/__init__.py
@@ -1,0 +1,2 @@
+# TODO: all of this should be upstreamed into ndspy
+from . import rle, huffman

--- a/formats/compression/huffman.py
+++ b/formats/compression/huffman.py
@@ -1,0 +1,29 @@
+import struct
+
+def decompress(data):  # sourcery skip: remove-unreachable-code
+    """
+    Decompress HUFF-compressed data.
+    """
+    
+    block_size = 8
+    
+    if data[0] == 0x24:
+        block_size = 4
+    elif data[0] == 0x28:
+        block_size = 8
+    else:
+        raise TypeError("This isn't a HUFF-compressed file.")
+    
+    dataLen = struct.unpack_from('<I', data)[0] >> 8
+    
+    treeSize = (data[4] + 1) * 2
+    treeEnd = (4+treeSize)
+    
+    out = bytearray(dataLen)
+    inPos, outPos = 5, 0
+    
+    
+    
+    raise NotImplementedError("huffman decompression")
+    
+    return bytes(out)

--- a/formats/compression/rle.py
+++ b/formats/compression/rle.py
@@ -1,0 +1,53 @@
+import struct
+
+def decompress(data):  # sourcery skip: hoist-if-from-if
+    """
+    Decompress RLE-compressed data.
+    """
+    
+    if data[0] != 0x30:
+        raise TypeError("This isn't an RLE-compressed file.")
+    
+    dataLen = struct.unpack_from('<I', data)[0] >> 8
+    
+    out = bytearray(dataLen)
+    inPos, outPos = 4, 0
+    
+    while dataLen > 0:
+        if inPos >= len(data):
+            raise EOFError("Invalid RLE-compressed file: data stream is too short")
+        
+        d = data[inPos]; inPos += 1
+        
+        compressed = (d & 0x80) != 0
+        n = d & 0x7f
+        
+        if compressed:
+            if inPos >= len(data):
+                raise EOFError("Invalid RLE-compressed file: data stream is too short")
+            n+=3
+            if dataLen - n < 0:
+                raise EOFError("Invalid RLE-compressed file: data stream is too long")
+            
+            b = data[inPos]; inPos += 1
+            for _ in range(n):
+                out[outPos] = b
+                outPos += 1; dataLen -= 1
+        else:
+            if inPos + n >= len(data):
+                raise EOFError("Invalid RLE-compressed file: data stream is too short")
+            n+=1
+            if dataLen - n < 0:
+                raise EOFError("Invalid RLE-compressed file: data stream is too long")
+            
+            for _ in range(n):
+                out[outPos] = data[inPos]
+                outPos += 1; inPos += 1; dataLen -= 1
+    
+    if inPos < len(data):
+        # the input may be 4-byte aligned
+        inPos = inPos - (inPos % 4) + (4 if inPos % 4 != 0 else 0)
+        if inPos < len(data):
+            raise EOFError("Invalid RLE-compressed file: data stream is too long")
+    
+    return bytes(out)


### PR DESCRIPTION
Running `flora bg extract` on literally all files in `bg` reveals that there are a few that can't be extracted. Looking at these files in Tinke works, so it's obviously possible; the commonality between all problematic cases was that they weren't LZ10-compressed, but instead use either RLE (for images that are mostly blank) or HUFF (for images with a lot of organic detail?).

This PR aims to implement these two (de)compression schemes, allowing for all image assets to be managed by Flora. It's a WIP since right now I have no idea how Huffman Compression works. I also think this should probably be added upstream in `ndspy` instead, but for now this would make things work.