### PR TITLE
Fancy CLI path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Some unused variants of puzzles can't be extracted yet through Flora, as well as
 * [click](https://pypi.org/project/click/)
 * [pillow](https://pypi.org/project/pillow/)
 * [ndspy](https://pypi.org/project/ndspy/)
+* Optional: [tqdm](https://pypi.org/project/tqdm) (to display a progress bar for long-running processes)
 
 To install all modules, use: `pip install -r requirements.txt`
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,89 @@
+import os
+from tqdm import tqdm
+
+def cli_file_pairs(input = None, output = None, *, in_ending = None, out_ending = None, recursive = False):
+    """
+    Given the file path inputs to the various CLI commands, determines which input files should be operated on and mapped to which output files.
+
+    Input paths are handled as follows:
+    - If the input is a file, that file will be used.
+    - If the input is a directory, all files in this directory (with the file ending `in_ending`) will be separately treated as input paths.
+    - If there is no input (which also means there's no output), the current working directory is used as both input and output
+      (which should be fine since most commands produce files of a different ending).
+    
+    Assuming the input is a file, then if the output is the same this pair is used as-is. Otherwise, if the output isn't specified (or a directory)
+    he output path is *inferred* like this:
+        - If the input ends with the expected file ending, that is stripped and replaced with the output file ending.
+          It's expected that if a user wants more control over this file extension, they should provide an output manually for each input file.
+        - If the input has a different ending (or none at all), the output file ending is simply appended to the full name.
+    
+    This same inference is used if the input is a directory: here we have multiple input paths, for which the targets can not have been specified,
+    and so the inference is applied to each of them separately. The output must be a directory (or the input directory itself if not specified) and
+    all the output paths are calculated such that input paths relative to the input directory become output paths relative to the output directory
+    (i.e. `in/a/b/c.input` becomes `out/a/b/c.output`). If the output exists but isn't a directory, the CLI exits with an error explaining how this doesn't make sense.
+    """
+
+    if input is None:
+        input = "."
+    
+    if not os.path.exists(input):
+        raise FileNotFoundError(input)
+    
+    def listfiles(path):
+        if recursive:
+            for (dp, _, fn) in os.walk(path, topdown=True):
+                for f in fn:
+                    yield os.path.join(dp, f)
+        else:
+            for f in os.listdir(path):
+                if not os.path.isfile(os.path.join(path, f)):
+                    continue
+                yield os.path.join(path, f)
+    
+    def filter_infer(input):
+        if in_ending is not None and not input.lower().endswith(in_ending):
+            return None
+        if out_ending is not None and input.lower().endswith(out_ending):
+            return None
+        
+        output = input
+        if in_ending is not None and input.lower().endswith(in_ending):
+            output = input[:-len(in_ending)]
+        if out_ending is None:
+            raise ValueError("Can't infer output file names without a target file ending specified")
+        output += out_ending
+        return output
+    
+    input_dir = ""
+    input_paths = []
+    if os.path.isfile(input):
+        input_dir, ip = os.path.split(input)
+        input_paths = [ip]
+    else:
+        input_dir = input
+        input_paths = [os.path.relpath(f, input_dir) for f in listfiles(input)]
+    rel_pairs = [(ip, filter_infer(ip)) for ip in input_paths]
+    rel_pairs = [(ip, op) for (ip, op) in rel_pairs if op is not None]
+    
+    if output is None:
+        output = input_dir
+
+    if os.path.isfile(input) and not os.path.isdir(output) and os.path.split(output)[1] != '':
+        return [(input, output)]
+    
+    if os.path.isfile(output):
+        raise OSError(f"Output path exists but is not a directory: '{output}'")
+    output_dir = output
+    
+    pairs = [(os.path.join(input_dir, ip), os.path.join(output_dir, op)) for (ip, op) in rel_pairs]
+    return pairs
+
+def foreach_file_pair(pairs, fn, quiet = False):
+    if not quiet:
+        progress = tqdm(pairs)
+        for (input, output) in progress:
+            progress.set_description(input)
+            fn(input, output)
+    else:
+        for (input, output) in pairs:
+            fn(input, output)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
 import os
-from tqdm import tqdm
 
 def cli_file_pairs(input = None, output = None, *, in_ending = None, out_ending = None, recursive = False):
     """
@@ -79,11 +78,16 @@ def cli_file_pairs(input = None, output = None, *, in_ending = None, out_ending 
     return pairs
 
 def foreach_file_pair(pairs, fn, quiet = False):
-    if not quiet:
-        progress = tqdm(pairs)
-        for (input, output) in progress:
-            progress.set_description(input)
-            fn(input, output)
-    else:
-        for (input, output) in pairs:
-            fn(input, output)
+    try:
+        from tqdm import tqdm
+        if not quiet:
+            progress = tqdm(pairs)
+            for (input, output) in progress:
+                progress.set_description(input)
+                fn(input, output)
+            return
+    except ImportError:
+        # TQDM isn't installed; just don't show a progress bar.
+        pass
+    for (input, output) in pairs:
+        fn(input, output)


### PR DESCRIPTION
Here's another fun idea: right now the easiest way to just "convert all the files in the game to a usable format" is to write a short shell snippet a la
```bash
for f in **/*.gds; do
flora gds extract $f ${f/%.gds/.json/}
done
```
But like, who knows how to do that?? I only do because ~~I googleded it all~~ I'm just cool like that, but this PR is an idea to make this easier for regular users too.

Essentially you can specify input and output directories now, and you can also omit the output path entirely if you're fine with a standard file ending replacement. You could even omit the input path, and it would just default to doing the current working directory! (Which is helpful in my case, because I've put Flora on my `$PATH` and can use it where I need it). This would shorten the above to `flora gds extract` in the game root... that's it!

In this PR I've built the framework for doing all the path calculations required for this; I've also made it so there's a fancy progress bar if you're working with a lot of files, unless it's suppressed with the `--quiet` flag. Thought that made sense, since there are a lot of scripts and assets, and my bash script method not giving any indication of progress is always very unsatisfying.

The entire thing is currently only implemented for the command I used as an example, because I'm mostly just playing around & looking for feedback. It should be extremely easy to integrate in the other commands too tho.