### PR TITLE
Dev QoL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__/
 *.pyc
+.vscode/
+/venv/
 
 releases/
 scripts/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some unused variants of puzzles can't be extracted yet through Flora, as well as
 * [pillow](https://pypi.org/project/pillow/)
 * [ndspy](https://pypi.org/project/ndspy/)
 
-To install all modules, use: `pip install click pillow ndspy` &nbsp;/ &nbsp;`py -m pip install click pillow ndspy`
+To install all modules, use: `pip install -r requirements.txt`
 
 ### Special thanks to:
 * [pleonex](https://github.com/pleonex/) for his tool [Tinke](https://github.com/pleonex/Tinke), which gave me a base for file formats

--- a/formats/__init__.py
+++ b/formats/__init__.py
@@ -1,1 +1,1 @@
-from formats import gds, bg, pcm, puzzle, rom
+from formats import gds, bg, pcm, puzzle, ndsrom

--- a/formats/puzzle.py
+++ b/formats/puzzle.py
@@ -35,7 +35,7 @@ def cli(romfile, puzzle, out_dir, lang):
     except FileExistsError:
         pass
 
-    print("") #newline lol
+    # print("") #newline lol
 
     if id.startswith("A5F"): #Curious Village
         #TODO: get files called from the script?

--- a/main.py
+++ b/main.py
@@ -13,5 +13,5 @@ cli.add_command(formats.pcm.cli, "pcm")
 cli.add_command(formats.puzzle.cli, "puzzle")
 
 if __name__ == "__main__":
-    print(f"Flora v{v} by patataofcourse\n")
+    # print(f"Flora v{v} by patataofcourse\n")
     cli() #TODO: managing exceptions, -v

--- a/main.py
+++ b/main.py
@@ -3,7 +3,10 @@ import click
 import formats
 from version import v
 
-@click.group(name=f"flora")
+CONTEXT_SETTINGS = dict(help_option_names = ['--help', '-h', '-?'])
+
+@click.group(name="flora", context_settings=CONTEXT_SETTINGS)
+@click.version_option(v, '--version', '-v', prog_name="flora", message=f"Flora v{v} by patataofcourse")
 def cli():
     pass
 
@@ -13,5 +16,4 @@ cli.add_command(formats.pcm.cli, "pcm")
 cli.add_command(formats.puzzle.cli, "puzzle")
 
 if __name__ == "__main__":
-    # print(f"Flora v{v} by patataofcourse\n")
-    cli() #TODO: managing exceptions, -v
+    cli() #TODO: managing exceptions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click
+pillow
+ndspy


### PR DESCRIPTION
Okay yeah, I should've probably made this one first. Here's what I did:
- On Arch (for example) all python packages are managed by the global package manager, so to install something like `ndspy` I *have to* use a venv; in general, the `.gitignore` now allows for one called `venv` in the project folder.
- The readme still lists dependencies, but also they're now written in a proper `requirements.txt` to ease installation (and eventually, if needed, enforce version requirements).
- Amend to the previous commit that renamed the `formats.rom` package, because the import wasn't changed.
- Flora is a tool that's very useful to run a lot of times in a script, but for that it should be (or at least have the option to be) completely quiet. So for now the `print`s on each run should go, and version info should probably be displayed in the help and behind a `--version` flag (the latter is done now)